### PR TITLE
Do not lint subcharts. Update cert-manager crds

### DIFF
--- a/apps/infrastructure/cert-manager/templates/cert-manager.crds.yaml
+++ b/apps/infrastructure/cert-manager/templates/cert-manager.crds.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -231,7 +231,7 @@ spec:
       served: true
       storage: false
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -821,7 +821,7 @@ spec:
       served: true
       storage: false
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2383,7 +2383,7 @@ spec:
       served: true
       storage: false
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -4321,7 +4321,7 @@ spec:
       served: true
       storage: false
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6259,7 +6259,7 @@ spec:
       served: true
       storage: false
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -25,5 +25,5 @@ helm repo add jetstack https://charts.jetstack.io/
 while IFS= read -d '' -r file; do
   helm dependencies update "$(dirname "$file")" || true
   helm dependencies build "$(dirname "$file")"
-  helm lint --with-subcharts "$(dirname "$file")"
+  helm lint "$(dirname "$file")"
 done < <(find . -name 'Chart.yaml' -print0)


### PR DESCRIPTION
Helm was updated and caused previously ok subcharts to fail. It's not a good idea to lint subcharts (there's nothing I can do), so I disabled that. Also updated the cert-manager CRDs to use a newer API version. 